### PR TITLE
fix: 공개 API 요청 시 JWT 인증 필터에서 예외 발생하지 않도록 수정

### DIFF
--- a/src/main/java/Sookmyung/Lingo/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Sookmyung/Lingo/common/jwt/JwtAuthenticationFilter.java
@@ -24,26 +24,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (request.getRequestURI().startsWith("/public/")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
 
         try {
             // 1. Request Header에서 JWT 토큰 추출
             String token = jwtTokenProvider.resolveToken(request);
 
-            if (token != null && jwtTokenProvider.validateToken(token)) {
-                // 블랙리스트 검사
+            if (token != null) {
+                if (!jwtTokenProvider.validateToken(token)) {
+                    // 유효하지 않은 토큰이 왔으면 → 그냥 인증 안 함 (예외 안 던지고)
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 if (Boolean.TRUE.equals(redisTemplate.hasKey("blacklist:" + token))) {
-                    throw new CustomException(ErrorCode.UNAUTHORIZED_TOKEN);
+                    filterChain.doFilter(request, response);
+                    return;
                 }
 
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
 
-            // 유효하지 않거나 없는 토큰은 그냥 통과 (permitAll 등에선 인증 객체 없이도 가능)
             filterChain.doFilter(request, response);
         } catch (CustomException ex) {
             // JSON 형태로 응답 내려주기


### PR DESCRIPTION
- JWT 토큰이 없는 요청에 대해 null 체크 후 인증 로직 생략
- 유효하지 않은 토큰이나 블랙리스트 토큰도 예외 없이 필터 통과 처리
- 인증이 필요한 요청은 Spring Security가 자동으로 차단하도록 유지
- 공개 API(`/member/**` 등) 접근 시 401 예외 발생하지 않도록 개선

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
