### PR TITLE
fix: 공개 API에 대해 JWT 인증 필터 우회 처리 로직 추가

### DIFF
--- a/src/main/java/Sookmyung/Lingo/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Sookmyung/Lingo/common/jwt/JwtAuthenticationFilter.java
@@ -25,6 +25,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        // Public API인 경우 필터링하지 않고 다음 필터로 넘어감
+        if (isPublicApi(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
             // 1. Request Header에서 JWT 토큰 추출
             String token = jwtTokenProvider.resolveToken(request);
@@ -58,6 +64,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 여기서 return 해서 체인 진행 중단
             return;
         }
+    }
+
+    private boolean isPublicApi(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri.equals("/member/login") ||
+                uri.equals("/member/signup") ||
+                uri.equals("/member/check-email") ||
+                uri.startsWith("/member/reset-password") ||
+                uri.equals("/member/find-email") ||
+                uri.equals("/member/reissue");
     }
 
 }


### PR DESCRIPTION
- 로그인, 회원가입, 이메일 중복 확인, 비밀번호 찾기 등 인증이 필요 없는 공개 API를 명시적으로 필터링하여 JWT 검증 로직을 건너뛰도록 수정
- access token이 존재하더라도 유효하지 않거나 블랙리스트에 포함된 경우에도 public API는 차단되지 않도록 예외 처리
- 재발급(/member/reissue) 엔드포인트도 동일하게 필터 제외

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
