### PR TITLE
feat: 공개 API 요청 시 로그아웃된 토큰도 허용되도록 JWT 필터 개선

### DIFF
--- a/src/main/java/Sookmyung/Lingo/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Sookmyung/Lingo/common/jwt/JwtAuthenticationFilter.java
@@ -25,28 +25,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // Public API인 경우 필터링하지 않고 다음 필터로 넘어감
+        String token = jwtTokenProvider.resolveToken(request);
+
+        // 공개 API는 무조건 통과
         if (isPublicApi(request)) {
             filterChain.doFilter(request, response);
             return;
         }
 
         try {
-            // 1. Request Header에서 JWT 토큰 추출
-            String token = jwtTokenProvider.resolveToken(request);
-
             if (token != null) {
+                // 만료된 토큰
                 if (!jwtTokenProvider.validateToken(token)) {
-                    // 유효하지 않은 토큰이 왔으면 → 그냥 인증 안 함 (예외 안 던지고)
-                    filterChain.doFilter(request, response);
-                    return;
+                    throw new CustomException(ErrorCode.UNAUTHORIZED_TOKEN);
                 }
 
+                // 로그아웃된 토큰
                 if (Boolean.TRUE.equals(redisTemplate.hasKey("blacklist:" + token))) {
-                    filterChain.doFilter(request, response);
-                    return;
+                    throw new CustomException(ErrorCode.UNAUTHORIZED_TOKEN);
                 }
 
+                // 유효한 토큰 → 인증 객체 등록
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }


### PR DESCRIPTION
- /member/login, /signup, /check-email 등 공개 API 요청은 JWT 필터 인증 로직 무시
- access token이 Redis 블랙리스트에 있더라도 공개 API 요청 시에는 401 에러 반환하지 않도록 수정
- 예외 발생 시 JSON 응답으로 통일

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
