### PR TITLE
fix: 토큰 없이 비밀번호 변경 API 접근 가능한 문제 수정

### DIFF
--- a/src/main/java/Sookmyung/Lingo/domains/member/controller/MemberController.java
+++ b/src/main/java/Sookmyung/Lingo/domains/member/controller/MemberController.java
@@ -1,7 +1,10 @@
 package Sookmyung.Lingo.domains.member.controller;
 
+import Sookmyung.Lingo.common.exception.CustomException;
+import Sookmyung.Lingo.common.exception.ErrorCode;
 import Sookmyung.Lingo.common.jwt.JwtTokenProvider;
 import Sookmyung.Lingo.common.jwt.ReissueRequest;
+import Sookmyung.Lingo.domains.member.domain.Member;
 import Sookmyung.Lingo.domains.member.dto.findEmail.FindEmailRequest;
 import Sookmyung.Lingo.domains.member.dto.findEmail.FindEmailResponse;
 import Sookmyung.Lingo.domains.member.dto.login.LoginRequest;
@@ -23,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -94,16 +98,22 @@ public class MemberController {
     // 비밀번호 변경 - 현재 비밀번호 확인
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/change-password/check-current")
-    public CurrentPasswordResponse checkCurrentPassword(@Valid @RequestBody CurrentPasswordRequest request) {
-        boolean isValid = memberService.checkCurrentPassword(request);
+    public CurrentPasswordResponse checkCurrentPassword(@AuthenticationPrincipal Member member, @Valid @RequestBody CurrentPasswordRequest request) {
+        if (member == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_TOKEN);
+        }
+        boolean isValid = memberService.checkCurrentPassword(member, request);
         return new CurrentPasswordResponse(isValid);
     }
 
     // 비밀번호 변경 - 새 비밀번호로 변경
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/change-password")
-    public ResponseEntity<?> changePassword(@Valid @RequestBody NewPasswordRequest request) {
-        memberService.changePassword(request);
+    public ResponseEntity<?> changePassword(@AuthenticationPrincipal Member member, @Valid @RequestBody NewPasswordRequest request) {
+        if (member == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_TOKEN);
+        }
+        memberService.changePassword(member, request);
         return ResponseEntity.ok(new SimpleResponse("비밀번호가 변경되었습니다."));
     }
 

--- a/src/main/java/Sookmyung/Lingo/domains/member/service/MemberService.java
+++ b/src/main/java/Sookmyung/Lingo/domains/member/service/MemberService.java
@@ -275,18 +275,15 @@ public class MemberService {
     }
 
     // 비밀번호 변경 - 현재 비밀번호 확인
-    public boolean checkCurrentPassword(CurrentPasswordRequest request) {
-        Member member = authUtil.getCurrentMember();
+    public boolean checkCurrentPassword(Member member, CurrentPasswordRequest request) {
         if (!passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
-            return false; // 현재 비밀번호가 일치하지 않으면 false 반환
+            return false;
         }
         return true; // 현재 비밀번호가 일치하면 true 반환
     }
 
     // 비밀번호 변경 - 새 비밀번호로 변경
-    public void changePassword(NewPasswordRequest request) {
-        Member member = authUtil.getCurrentMember();
-
+    public void changePassword(Member member, NewPasswordRequest request) {
         // 새 비밀번호와 확인 비밀번호가 일치하는지 확인
         if (!request.getNewPassword().equals(request.getConfirmNewPassword())) {
             throw new CustomException(ErrorCode.NOT_MATCH_PASSWORD_CONFIRM);


### PR DESCRIPTION
- @AuthenticationPrincipal Member 주입을 통해 인증된 사용자 정보 직접 활용
- checkCurrentPassword 및 changePassword 메서드에서 authUtil 중복 호출 제거
- JWT 토큰이 없는 경우 401 Unauthorized 발생하도록 흐름 개선
- SecurityContext 인증 객체를 활용한 보안 강화

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
